### PR TITLE
Handle spaces in paths when downloading catalog.

### DIFF
--- a/tools/download-catalog.sh
+++ b/tools/download-catalog.sh
@@ -24,25 +24,24 @@ SCRIPT_DIR=$(dirname "${THIS_SCRIPT}")
 
 # Calculate absolute path to imports/
 # Start with ontology/ as imports/ might not exist
-ONTO_DIR=${SCRIPT_DIR}/../src/ontology
+ONTO_DIR="${SCRIPT_DIR}/../src/ontology"
 ABS_ONTO_DIR=$(cd ${ONTO_DIR}; printf %s "${PWD}")
 ABS_IMPORTS_DIR=${ABS_ONTO_DIR}/imports
 
 # Create imports dir
-mkdir -p ${ABS_IMPORTS_DIR}
+mkdir -p "${ABS_IMPORTS_DIR}"
 
 # Requires wget (brew install wget)
-WGET_OPTS="-nc --directory-prefix=${ABS_IMPORTS_DIR}"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/MFOEM.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/MFO.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/dideo.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/ro/core.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/ro/releases/2017-07-19/ro.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/IAO.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/ro/annotations.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/ro/bfo-axioms.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/ro/bfo-classes-minimal.owl"
-wget ${WGET_OPTS} "http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/MFOEM.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/MFO.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/dideo.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/ro/core.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/ro/releases/2017-07-19/ro.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/IAO.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/ro/annotations.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/ro/bfo-axioms.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/ro/bfo-classes-minimal.owl"
+wget -nc --directory-prefix="${ABS_IMPORTS_DIR}" "http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"
 
 echo "Done."


### PR DESCRIPTION
Remove _clever_ method of constructing command line arguments to avoid handling two expansion passes.